### PR TITLE
Comply with upcoming flashlight version >= 1.0.0

### DIFF
--- a/R/vivi.R
+++ b/R/vivi.R
@@ -223,27 +223,25 @@ vividImportance.default <- function(fit,
   )
 
 
-
-
-  # extract importance
+  # Extract importance
   suppressWarnings(
     imp <- light_importance(fl, m_repetitions = numPerm)
   )
+  # Column names and order in imp$data:
+  #   label  metric  variable  value  error  (flashlight < 1.0.0)
+  #   label_ metric_ variable_ value_ error_ (flashlight >=1.0.0)
+  impDf <- imp$data[, 3:5]
+  names(impDf) <- c('Variable', 'Importance', 'Std_Error')
 
-  if(showVimpError){
-    impDf <- imp$data[,c(3:5)]
-    names(impDf) <- c('Variable', 'Importance', 'Std_Error')
+  if(showVimpError) {
     print(impDf)
   }
 
-
-
-  importance <- imp$data[, 3:4]
-  if (any(is.nan(importance$value))) {
-    importance$value <- 1
+  if (any(is.nan(impDf$Importance))) {
+    impDf$Importance <- 1
     message("Flashlight importance works for numeric and numeric binary response only; setting importance to 1.")
   }
-  importance <- setNames(importance$value, as.character(importance$variable)) # turn into named vector
+  importance <- setNames(impDf$Importance, as.character(impDf$Variable)) # turn into named vector
 
   return(importance)
 }
@@ -511,14 +509,21 @@ vividInteraction.default <- function(fit,
     normalize = normalized, n_max = nmax
   )$data
 
+  # Column names and order in res:
+  #   label  variable  value  error  (flashlight < 1.0.0)
+  #   label_ variable_ value_ error_ (flashlight >=1.0.0)
+
+  variable <- res[[2L]]
+  value <- res[[3L]]
+
   # reorder
-  res[["variable"]] <- reorder(res[["variable"]], res[["value"]])
+  variable <- reorder(variable, value)
 
   # create matrix of values
-  vars2 <- t(simplify2array(strsplit(as.character(res[["variable"]]), ":"))) # split/get feature names
+  vars2 <- t(simplify2array(strsplit(as.character(variable), ":"))) # split/get feature names
   mat <- matrix(0, length(ovars), length(ovars)) # create matrix
   rownames(mat) <- colnames(mat) <- ovars # set names
-  mat[vars2] <- res[["value"]] # set values
+  mat[vars2] <- value # set values
   mat[lower.tri(mat)] <- t(mat)[lower.tri(mat)]
   return(mat)
 }


### PR DESCRIPTION
Hello vivid team

Thanks for your beautiful package!

I am the maintainer of {flashlight}, and currently working on a relatively large update (version 1.0.0) that will be released in 1-2 months. 

One of the changes affects the column names (not the column order) of the `data` objects resulting from calling `light_importance()` and `light_interaction()`. This PR tries to make your code working with old and new {flashlight} versions.

Note: There is a `reorder()` after calculation of the pairwise interaction values. I don't think it is necessary for the matrix organization below, so we might drop it.